### PR TITLE
ApplicationFile: store files according to server path

### DIFF
--- a/src/application/applicationfile.cpp
+++ b/src/application/applicationfile.cpp
@@ -139,7 +139,7 @@ void ApplicationFile::startDownload()
 
     url.setUrl(m_uri);
 
-    localFilePath = applicationFilePath(fileName);
+    localFilePath = applicationFilePath(fileName, m_serverDirectory);
     m_localFilePath = QUrl::fromLocalFile(localFilePath).toString();
     emit localFilePathChanged(m_localFilePath);
 
@@ -311,9 +311,9 @@ void ApplicationFile::cleanupTempPath()
     dir.removeRecursively();
 }
 
-QString ApplicationFile::applicationFilePath(const QString &fileName)
+QString ApplicationFile::applicationFilePath(const QString &fileName, const QString &serverDirectory)
 {
-    return QDir(QUrl(m_localPath).toLocalFile()).filePath(fileName);
+    return QDir(QUrl(m_localPath).toLocalFile() + "/" + serverDirectory).filePath(fileName);
 }
 
 void ApplicationFile::initializeFtp()

--- a/src/application/applicationfile.h
+++ b/src/application/applicationfile.h
@@ -220,7 +220,7 @@ private:
     void updateError(TransferError error, const QString &errorString);
     QString generateTempPath();
     void cleanupTempPath();
-    QString applicationFilePath(const QString &remoteFilePath);
+    QString applicationFilePath(const QString &remoteFilePath, const QString &serverDirectory);
     void initializeFtp();
     void cleanupFtp();
     void cleanupFile();

--- a/src/pathview/GCodeSync.qml
+++ b/src/pathview/GCodeSync.qml
@@ -25,7 +25,7 @@ import Machinekit.Application 1.0
 import Machinekit.PathView 1.0
 
 QtObject {
-    property var status: {"synced": false}
+    property var status: { "synced": false }
     property var model: undefined
 
     property int _lastLine: 1

--- a/src/pathview/SourceView.qml
+++ b/src/pathview/SourceView.qml
@@ -95,10 +95,14 @@ Item {
                         Label {
                             anchors.fill: parent
                             anchors.rightMargin: 5
-                            text: String(lineNumber)
+                            verticalAlignment: Text.AlignVCenter
+                            wrapMode: Text.NoWrap
+                            elide: Text.ElideRight
+                            maximumLineCount: 1
                             horizontalAlignment: Text.AlignRight
                             color: selected ? "white" : label.color
                             font: dummyLabel.font
+                            text: String(lineNumber)
                         }
                     }
 
@@ -114,8 +118,12 @@ Item {
                             id: label
                             anchors.fill: parent
                             anchors.leftMargin: 5
-                            text: String(gcode).trim()
+                            verticalAlignment: Text.AlignVCenter
+                            wrapMode: Text.NoWrap
+                            elide: Text.ElideRight
+                            maximumLineCount: 1
                             font: dummyLabel.font
+                            text: String(gcode).trim()
                         }
                     }
 

--- a/src/pathview/gcodeprogramloader.cpp
+++ b/src/pathview/gcodeprogramloader.cpp
@@ -46,7 +46,7 @@ void GCodeProgramLoader::load()
     QString remotePath = QUrl(m_remotePath).toLocalFile();
     QString remoteFilePath;
 
-    if (localFilePath.indexOf(localPath) == 0)
+    if (localFilePath.indexOf(localPath) == 0)  // file is in local download path
     {
         remoteFilePath = QDir(remotePath).filePath(localFilePath.mid(localPath.length() + 1));
     }


### PR DESCRIPTION
Fixes sync problems when the remote file is stored in a subdirectory of the main `nc_files` path.