### PR TITLE
build: remove redundant qt version number

### DIFF
--- a/build/deployment-scripts/android_armv7.ini
+++ b/build/deployment-scripts/android_armv7.ini
@@ -2,7 +2,6 @@
 name=machinekit-client
 realname=MachinekitClient
 shortname=mc
-qtversion=5.7
 arch=armv7
 compiler=android_armv7
 system=android

--- a/build/deployment-scripts/linux_x64.ini
+++ b/build/deployment-scripts/linux_x64.ini
@@ -2,7 +2,6 @@
 name=machinekit-client
 shortname=mc
 realname=MachinekitClient
-qtversion=5.7
 arch=x64
 compiler=gcc_64
 system=linux


### PR DESCRIPTION
and triggers build with Qt 5.8